### PR TITLE
Don't rely on fatal warnings to check for invalid logger params

### DIFF
--- a/lib/App/Commando/Logger.pm
+++ b/lib/App/Commando/Logger.pm
@@ -22,12 +22,11 @@ sub BUILDARGS {
 sub BUILD {
     my ($self) = @_;
 
-    eval {
-        $self->{_fh} = openhandle($self->device);
-        open($self->{_fh}, '>>', $self->device) if !defined $self->{_fh};
-    };
-    if ($@) {
-        croak 'Can\'t open log device';
+    $self->{_fh} = openhandle($self->device);
+
+    if (!defined $self->{_fh}) {
+        $self->device and open($self->{_fh}, '>>', $self->device)
+            or croak 'Can\'t open log device';
     }
 
     return $self;


### PR DESCRIPTION
Moo 2.0 will stop applying fatal warnings to classes using it.  Rather
than rely on fatal warnings to check for invalid logger params, check it
ourselves.  Also, check the return value of the open call to detect
other problems.

Fixes #1.
